### PR TITLE
[BE-#346] Updates in payment methods

### DIFF
--- a/sequelize/migrations/20230522102800-add-payment-methods.js
+++ b/sequelize/migrations/20230522102800-add-payment-methods.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const Sequelize = require('sequelize');
+const Op = Sequelize.Op;
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            await queryInterface.bulkInsert(
+                'sh_tab_payment_methods',
+                [
+                    {
+                        payment_method_id: 12,
+                        description: 'Galicia 33',
+                        allows_installments: false,
+                    },
+                    {
+                        payment_method_id: 13,
+
+                        description: 'Galicia Cosundino',
+                        allows_installments: false,
+                    },
+                ],
+                { transaction }
+            );
+            await queryInterface.bulkInsert(
+                'sh_tab_payment_method_installments',
+                [
+                    {
+                        id: 24,
+                        id_payment_method: 12,
+                        installments: 1,
+                        interest_rate: 0.0,
+                    },
+                    {
+                        id: 25,
+                        id_payment_method: 13,
+                        installments: 1,
+                        interest_rate: 0.0,
+                    },
+                ],
+                { transaction }
+            );
+
+            transaction.commit();
+        } catch (err) {
+            await this.down(queryInterface, Sequelize);
+            transaction.rollback();
+            throw err;
+        }
+    },
+
+    async down(queryInterface, Sequelize) {
+        await queryInterface.bulkDelete(
+            'sh_tab_payment_method_installments',
+            { id_payment_method: { [Op.in]: [12, 13] } },
+            {}
+        );
+        await queryInterface.bulkDelete('sh_tab_payment_methods', { payment_method_id: { [Op.in]: [12, 13] } }, {});
+    },
+};

--- a/sequelize/migrations/20230522105046-add-enabled-deleted-columns-to-payment-methods.js
+++ b/sequelize/migrations/20230522105046-add-enabled-deleted-columns-to-payment-methods.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('sh_tab_payment_methods', 'enabled', {
+            type: Sequelize.DataTypes.BOOLEAN,
+            defaultValue: true,
+        });
+        await queryInterface.addColumn('sh_tab_payment_methods', 'deleted', {
+            type: Sequelize.DataTypes.BOOLEAN,
+            defaultValue: false,
+        });
+    },
+
+    async down(queryInterface, Sequelize) {
+        await queryInterface.removeColumn('sh_tab_payment_methods', 'enabled');
+        await queryInterface.removeColumn('sh_tab_payment_methods', 'deleted');
+    },
+};

--- a/sequelize/migrations/20230522110829-disable-point-and-todopago-payment-methods.js
+++ b/sequelize/migrations/20230522110829-disable-point-and-todopago-payment-methods.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const Sequelize = require('sequelize');
+const Op = Sequelize.Op;
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await queryInterface.bulkUpdate(
+                'sh_tab_payment_methods',
+                { enabled: false },
+                { payment_method_id: { [Op.in]: [3, 7, 8] } }
+            );
+            transaction.commit();
+        } catch (err) {
+            await this.down(queryInterface, Sequelize);
+            transaction.rollback();
+            throw err;
+        }
+    },
+
+    async down(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await queryInterface.bulkUpdate(
+                'sh_tab_payment_methods',
+                { enabled: true },
+                { payment_method_id: { [Op.in]: [3, 7, 8] } },
+                { transaction }
+            );
+            transaction.commit();
+        } catch (err) {
+            transaction.rollback();
+            throw err;
+        }
+    },
+};

--- a/server/cash/cash.service.js
+++ b/server/cash/cash.service.js
@@ -25,6 +25,7 @@ async function getPaymentMethods() {
             required: false,
             attributes: ['installments', 'interestRate'],
         },
+        where: { enabled: true },
     });
 }
 


### PR DESCRIPTION
# Summary
* Added `deleted` and `enabled` columns in `tab_payment_methods` table.
* Disabled `TodoPago`, `Point Débito` and `Point Crédito` payment methods.
* Added condition in the `getPaymentMethods` endpoint to fetch only enabled payment methods.